### PR TITLE
chore: add action to sync codebase to PL

### DIFF
--- a/.github/workflows/sync-codebase-to-protocol-land.yml
+++ b/.github/workflows/sync-codebase-to-protocol-land.yml
@@ -1,0 +1,29 @@
+name: sync-to-PL 
+on:
+    workflow_dispatch:
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: 'Checkout repo (default branch)'
+              uses: actions/checkout@v3
+              with:
+                  # fetch all history for all branches:
+                  fetch-depth: 0
+            - name: 'Checkout all branches'
+              run: |
+                  default_branch=$(git branch | grep '*' | sed 's/\* //')
+                  for abranch in $(git branch -a | grep -v HEAD | grep remotes | sed "s/remotes\/origin\///g"); do git checkout $abranch ; done
+                  git checkout $default_branch
+                  git branch -a
+            - name: 'Setup node 18'
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18.x
+            - name: 'Sync repo to Protocol Land'
+              run: npx @protocol.land/sync@0.5.0
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REPO_TITLE: ${{ github.event.repository.name }}
+                  REPO_DESCRIPTION: ${{ github.event.repository.description }}
+                  WALLET: ${{ secrets.WALLET }}


### PR DESCRIPTION
This PR Adds Github action workflow that uses [Protocol.Land](https://protocol.land/) and its [tools](https://github.com/labscommunity/protocol-land-sync)(protocol-land-sync) to store entire codebase on Arweave and register/update Protocol Land's AO process.

This workflow depends on WALLET (arweave wallet JWK) env added to the repo secrets with sufficient funds to be able to upload codebase on Arweave.

Currently workflow has to be triggered manually, but I'm happy to adjust that in the action if this needs to run based on a condition like merge to master.