### PR TITLE
fix: fix KyveSigner import issue with some bundlers

### DIFF
--- a/src/signing/chains/KyveSigner.ts
+++ b/src/signing/chains/KyveSigner.ts
@@ -1,4 +1,4 @@
-import { EthereumSigner } from "./";
+import EthereumSigner from "./ethereumSigner.js";
 import { SignatureConfig } from "../../constants";
 
 export default class KyveSigner extends EthereumSigner {


### PR DESCRIPTION
Fix KyveSigner throwing that it can't call EthereumSigner before it's initialised. With this fix we make sure EthereumSigner is initialised when we use it, the same pattern is actually used in other files, KyveSigner.ts is the only file having this problem.

For information my app is being bundled with [nitro](https://nitro.build/) 